### PR TITLE
Upgrading to latest version of Awesome-WebSocket

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "core-custom-event-client",
   "version": "0.0.0",
   "dependencies": {
-    "awesome-websocket": "0.0.22",
+    "awesome-websocket": "0.0.23",
     "polymer": "git://github.com/custom-elements/polymer#master",
     "polymer-build": ""
   },


### PR DESCRIPTION
There appears to be a memory leak in Reconnecting Websocket that is fixed in the latest version (.23) of awesome socket.
